### PR TITLE
Include lambda tag resources action to service role

### DIFF
--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -140,6 +140,7 @@ export class ServiceDeployIAM extends cdk.Stack {
                          "lambda:RemovePermission",
                          "lambda:InvokeFunction",
                          "lambda:ListTags",
+                         "lambda:TagResource",
                          "lambda:PutFunctionConcurrency"
                     ]
                })


### PR DESCRIPTION
It has been identified that some of the services required `lambda tag resources` permission.