### PR TITLE
DO-1382: Fix typo

### DIFF
--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -108,7 +108,7 @@ export class ServiceDeployIAM extends cdk.Stack {
                     resources: cloudWatchResources,
                     actions: [
                          "logs:CreateLogGroup",
-                         "logs:DescribeLogGroup",
+                         "logs:DescribeLogGroups",
                          "logs:DeleteLogGroup",
                          "logs:CreateLogStream",
                          "logs:DescribeLogStreams",


### PR DESCRIPTION
`DescribeLogGroup` is not valid `DescribeLogGroups` is :slightly_smiling_face: 