### PR TITLE
Add service name to log group permissions

### DIFF
--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -85,7 +85,7 @@ export class ServiceDeployIAM extends cdk.Stack {
                     {
                          name: 'CLOUD_WATCH',
                          prefix: `arn:aws:logs:${region}:${accountId}:log-group:`,
-                         qualifiers: [`aws/lambda/${serviceName}*`, `aws/apigateway/${serviceName}*`],
+                         qualifiers: [`/aws/lambda/${serviceName}*`, `/aws/apigateway/${serviceName}*`, `${serviceName}*`],
                          actions: [
                               "logs:CreateLogGroup",
                               "logs:DescribeLogGroups",
@@ -436,15 +436,16 @@ export class ServiceDeployIAM extends cdk.Stack {
      static formatResourceQualifier(serviceName: string, prefix: string, qualifiers: string[]): string[] {
           let delimiter = "/";
           switch (serviceName) {
+               case "CLOUD_WATCH":
                case "STEP_FUNCTION":
                     delimiter = "";
+                    break;
                case "EVENT_BRIDGE":
                     delimiter = ":";
+                    break;
           }
 
-          return [
-               ...qualifiers,
-          ].filter(Boolean).map((qualifier) => { return `${prefix}${delimiter}${qualifier}` })
+          return qualifiers.filter(Boolean).map((qualifier) => { return `${prefix}${delimiter}${qualifier}` })
      }
 }
 

--- a/packages/serverless-deploy-iam/test/deploy-role.test.ts
+++ b/packages/serverless-deploy-iam/test/deploy-role.test.ts
@@ -34,7 +34,6 @@ describe('Deploy user policy', () => {
                PolicyName: stringLike("jestdeployersDefaultPolicy*"),
                PolicyDocument: {
                     Statement: arrayWith(
-
                          objectLike({
                               Action: "cloudformation:ValidateTemplate",
                               Effect: "Allow",
@@ -84,7 +83,6 @@ describe('Deploy user policy', () => {
                PolicyName: stringLike("jestdeployersDefaultPolicy*"),
                PolicyDocument: {
                     Statement: arrayWith(
-
                          objectLike({
                               Action: [
                                    "lambda:GetFunction",
@@ -101,6 +99,53 @@ describe('Deploy user policy', () => {
                                         "Fn::Join": [
                                              "",
                                              ["arn:aws:ssm:", { "Ref": "AWS::Region" }, ":", { "Ref": "AWS::AccountId" }, ":parameter/", { "Ref": "lambdaQualifier" }]
+                                        ]
+                                   }
+                              ]
+                         }),
+                    )
+               }
+          }));
+     });
+
+     test('has correct CloudWatch permissions', () => {
+          const app = new cdk.App();
+          const stack = new ServiceDeployIAM(app, 'jest-deploy-iam');
+          expectCDK(stack).to(haveResourceLike('AWS::IAM::Policy', {
+               PolicyName: stringLike("ServiceRolev1DefaultPolicy*"),
+               PolicyDocument: {
+                    Statement: arrayWith(
+                         objectLike({
+                              Action: [
+                                   "logs:CreateLogGroup",
+                                   "logs:DescribeLogGroups",
+                                   "logs:DeleteLogGroup",
+                                   "logs:CreateLogStream",
+                                   "logs:DescribeLogStreams",
+                                   "logs:DeleteLogStream",
+                                   "logs:FilterLogEvents"
+                              ],
+                              Effect: "Allow",
+                              Resource: [
+                                   {
+                                        "Fn::Join": [
+                                             "",
+                                             ["arn:aws:logs:", { "Ref": "AWS::Region" }, ":", { "Ref": "AWS::AccountId" }, ":log-group:/aws/lambda/jest*"],
+                                        ],
+                                   }, {
+                                        "Fn::Join": [
+                                             "",
+                                             ["arn:aws:logs:", { "Ref": "AWS::Region" }, ":", { "Ref": "AWS::AccountId" }, ":log-group:/aws/apigateway/jest*"]
+                                        ]
+                                   }, {
+                                        "Fn::Join": [
+                                             "",
+                                             ["arn:aws:logs:", { "Ref": "AWS::Region" }, ":", { "Ref": "AWS::AccountId" }, ":log-group:jest*"]
+                                        ]
+                                   }, {
+                                        "Fn::Join": [
+                                             "",
+                                             ["arn:aws:logs:", { "Ref": "AWS::Region" }, ":", { "Ref": "AWS::AccountId" }, ":log-group:", { "Ref": "cloudwatchQualifier" }]
                                         ]
                                    }
                               ]


### PR DESCRIPTION
Add the service name as a default CloudWatch permission.

This will allow developers to create custom log groups prefixed with the service name. 

`DO-1418`