### PR TITLE
Fix resource delimiters

### DIFF
--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -437,6 +437,10 @@ export class ServiceDeployIAM extends cdk.Stack {
           let delimiter = "/";
           switch (serviceName) {
                case "CLOUD_WATCH":
+               case "LAMBDA":
+               case "S3":
+               case "SNS":
+               case "SQS":
                case "STEP_FUNCTION":
                     delimiter = "";
                     break;

--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -305,7 +305,7 @@ export class ServiceDeployIAM extends cdk.Stack {
                     },
                     {
                          name: 'LAMBDA',
-                         prefix: `arn:aws:lambda:${region}:${accountId}:function`,
+                         prefix: `arn:aws:lambda:${region}:${accountId}:function:`,
                          qualifiers: [`${serviceName}*`],
                          actions: [
                               "lambda:GetFunction",

--- a/packages/serverless-deploy-iam/test/deploy-role.test.ts
+++ b/packages/serverless-deploy-iam/test/deploy-role.test.ts
@@ -93,12 +93,12 @@ describe('Deploy user policy', () => {
                                    {
                                         "Fn::Join": [
                                              "",
-                                             ["arn:aws:lambda:", { "Ref": "AWS::Region" }, ":", { "Ref": "AWS::AccountId" }, ":function/jest*"],
+                                             ["arn:aws:lambda:", { "Ref": "AWS::Region" }, ":", { "Ref": "AWS::AccountId" }, ":function:jest*"],
                                         ],
                                    }, {
                                         "Fn::Join": [
                                              "",
-                                             ["arn:aws:lambda:", { "Ref": "AWS::Region" }, ":", { "Ref": "AWS::AccountId" }, ":function/", { "Ref": "lambdaQualifier" }]
+                                             ["arn:aws:lambda:", { "Ref": "AWS::Region" }, ":", { "Ref": "AWS::AccountId" }, ":function:", { "Ref": "lambdaQualifier" }]
                                         ]
                                    }
                               ]
@@ -178,13 +178,13 @@ describe('CloudFormation service policy', () => {
                                    Action: "s3:*",
                                    Effect: "Allow",
                                    Resource: [
-                                        "arn:aws:s3:::/jest*",
-                                        "arn:aws:s3:::/jest*/*",
+                                        "arn:aws:s3:::jest*",
+                                        "arn:aws:s3:::jest*/*",
                                         {
                                              "Fn::Join": [
                                                   "",
                                                   [
-                                                       "arn:aws:s3:::/",
+                                                       "arn:aws:s3:::",
                                                        {
                                                             "Ref": "s3Qualifier"
                                                        }


### PR DESCRIPTION
Resource delimiters were set to `/` for most resources. This should not be the case. 

I've corrected this to set the delimiter to a blank space for the resources that require one.

The Lambda qualifier was also missing a colon. 