### PR TITLE
Force redeploy on parameter change

### DIFF
--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -69,7 +69,7 @@ export class ServiceDeployIAM extends cdk.Stack {
           // a parameter is altered, a change will be detected.
           const dummyPolicy : ResourcePolicy = {
                name: 'DUMMY',
-               resources: [`arn:aws:iam:${region}:999999999999:group${PARAMETER_HASH}`],
+               resources: [`arn:aws:iam:${region}:999999999999:group/${PARAMETER_HASH}`],
                actions: [
                     "iam:ListUsers"
                ]
@@ -444,6 +444,12 @@ export class ServiceDeployIAM extends cdk.Stack {
                value: version,
                description: 'The version of the resources that are currently provisioned in this stack',
                exportName: `${export_prefix}cdk-stack-version`,
+          });
+
+          new cdk.CfnOutput(this, `${export_prefix}ParameterHash`, {
+               value: version,
+               description: 'A hash of the parameter values provided.',
+               exportName: `${export_prefix}parameter-hash`
           });
 
           const parameterName = `/serverless-deploy-iam/${serviceName}/version`;

--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -69,7 +69,7 @@ export class ServiceDeployIAM extends cdk.Stack {
           // a parameter is altered, a change will be detected.
           const dummyPolicy : ResourcePolicy = {
                name: 'DUMMY',
-               resources: [`arn:aws:iam:${region}:999999999999:group/${PARAMETER_HASH}`],
+               resources: [`arn:aws::iam:999999999999:group/${PARAMETER_HASH}`],
                actions: [
                     "iam:ListUsers"
                ]

--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -69,7 +69,7 @@ export class ServiceDeployIAM extends cdk.Stack {
           // a parameter is altered, a change will be detected.
           const dummyPolicy : ResourcePolicy = {
                name: 'DUMMY',
-               resources: [`arn:aws::iam:999999999999:group/${PARAMETER_HASH}`],
+               resources: [`arn:aws:iam::999999999999:group/${PARAMETER_HASH}`],
                actions: [
                     "iam:ListUsers"
                ]

--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -69,8 +69,7 @@ export class ServiceDeployIAM extends cdk.Stack {
           // a parameter is altered, a change will be detected.
           const dummyPolicy : ResourcePolicy = {
                name: 'DUMMY',
-               prefix: `arn:aws:iam:${region}:999999999999:dummy_value`,
-               resources: [PARAMETER_HASH],
+               resources: [`arn:aws:iam:${region}:999999999999:group${PARAMETER_HASH}`],
                actions: [
                     "iam:ListUsers"
                ]


### PR DESCRIPTION
When updating a CDK parameter this doesn’t create a CloudFormation change set. 

To get around this we create a hash of the parameters and add this to the end of the IAM policy. This forces a deployment when parameters change.