### PR TITLE
Add enable vpc permissions env var

### DIFF
--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -40,6 +40,7 @@ interface PolicyStore {
 const SERVICE_NAME = process.env.SERVICE_NAME ? process.env.SERVICE_NAME : 'unknown-service'
 const STACK_SUFFIX = '-deploy-iam'
 const EXPORT_PREFIX = process.env.EXPORT_PREFIX ? process.env.EXPORT_PREFIX : SERVICE_NAME
+const ENABLE_VPC_PERMISSIONS = process.env.ENABLE_VPC_PERMISSIONS === "1";
 export class ServiceDeployIAM extends cdk.Stack {
      private policyStores: PolicyStore[];
 
@@ -237,8 +238,8 @@ export class ServiceDeployIAM extends cdk.Stack {
                ]
           }
 
-          if (sharedVPCParameter.valueAsString) {
-               serviceRole.policies.concat([
+          if (ENABLE_VPC_PERMISSIONS) {
+               serviceRole.policies = serviceRole.policies.concat([
                     {
                          name: 'EC2',
                          resources: [`*`],


### PR DESCRIPTION
This should fix the bug of shared vpc not being added. 

`sharedVPCParameter.valueAsString` doesn't work as parameters are not resolved during deployment time.