### PR TITLE
fix: move user actions to user prefix

### DIFF
--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -158,13 +158,20 @@ export class ServiceDeployIAM extends cdk.Stack {
                     },
                     {
                          name: 'IAM',
+                         prefix: `arn:aws:iam::${accountId}:user`,
+                         qualifiers: [`${serviceName}*`],
+                         actions: [
+                              "iam:CreateRole",
+                              "iam:CreateUser",
+                              "iam:PutUserPolicy",
+                         ]
+                    },
+                    {
+                         name: 'IAM',
                          prefix: `arn:aws:iam::${accountId}:role`,
                          qualifiers: [`${serviceName}*`],
                          actions: [
                               "iam:PassRole",
-                              "iam:CreateRole",
-                              "iam:CreateUser",
-                              "iam:PutUserPolicy",
                               "iam:GetRole",
                               "iam:DeleteRole",
                               "iam:GetRolePolicy",


### PR DESCRIPTION
I should have picked this up before... We need to run user related actions on users, not roles.