### PR TITLE
add schedule-group permissions to IAM deploy role policy

### DIFF
--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -243,6 +243,19 @@ export class ServiceDeployIAM extends cdk.Stack {
                          ]
                     },
                     {
+                         name: 'SCHEDULEGROUP',
+                         prefix: `arn:aws:scheduler:${region}:${accountId}:schedule-group`,
+                         qualifiers: [`${serviceName}*`],
+                         actions: [
+                           'scheduler:GetScheduleGroup',
+                           'scheduler:CreateScheduleGroup',
+                           'scheduler:UpdateScheduleGroup',
+                           'scheduler:DeleteScheduleGroup',
+                           'scheduler:TagResource',
+                           'scheduler:ListTagsForResource'
+                         ]
+                    },
+                    {
                          name: 'API_GATEWAY',
                          resources: [`*`],
                          actions: [


### PR DESCRIPTION
Serverless Stack started using AWS EventBridge Scheduler Schedule group feature. This change will grant the deloy role the permission to use the feature. 