### PR TITLE
Renaming Even Source Mappings is not possible without DELETE

### DIFF
--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -188,7 +188,8 @@ export class ServiceDeployIAM extends cdk.Stack {
                          actions: [
                               "lambda:GetEventSourceMapping",
                               "lambda:ListEventSourceMappings",
-                              "lambda:CreateEventSourceMapping"
+                              "lambda:CreateEventSourceMapping",
+                              "lambda:DeleteEventSourceMapping"
                          ]
                     },
                     {


### PR DESCRIPTION
Provide deploy user with `lambda:DeleteEventSourceMapping` privilege to allow for event source map renaming in Lambda functions.

This permission is already granted to the Role but the defined ARM format does not provide sufficient coverage.