### PR TITLE
Allow the deploy user to tag SNS topics.

### DIFF
--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -301,7 +301,8 @@ export class ServiceDeployIAM extends cdk.Stack {
                               "sns:DeleteTopic",
                               "sns:Subscribe",
                               "sns:Unsubscribe",
-                              "sns:ListSubscriptionsByTopic"
+                              "sns:ListSubscriptionsByTopic",
+                              "sns:TagResource",
                          ]
                     },
                     {


### PR DESCRIPTION
When you are wanting to tag an SNS Topic upon creation you are required to have the `:sns:TagResource` permissions.

This seems to happen when you refer to a topic by environment reference.

**References:**
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-topic.html#cfn-sns-topic-tags
 an SNS Topic
https://docs.aws.amazon.com/sns/latest/api/API_TagResource.html