### PR TITLE
fix: add slash to kms qualifier

### DIFF
--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -713,7 +713,6 @@ export class ServiceDeployIAM extends cdk.Stack {
                case "S3":
                case "SNS":
                case "SQS":
-               case "KMS":
                case "STEP_FUNCTION":
                     delimiter = "";
                     break;


### PR DESCRIPTION
Make KMS use the default behaviour of a slash. 

The resource arn looks like: `arn:aws:kms:ap-southeast-2:999999999999:keyclient-int*`
When it should look like: `arn:aws:kms:ap-southeast-2:999999999999:key/client-int*`