### PR TITLE
fix: grant access to all kms keys for that account

### DIFF
--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -454,8 +454,7 @@ export class ServiceDeployIAM extends cdk.Stack {
                     },
                     {
                          name: 'KMS',
-                         prefix: `arn:aws:kms:${region}:${accountId}:key`,
-                         qualifiers: [`${serviceName}*`],
+                         resources: [`arn:aws:kms:${region}:${accountId}:key/*`],
                          actions: [
                               "kms:CreateKey",
                               "kms:DescribeKey",


### PR DESCRIPTION
KMS keys ARNs are formed using their IDs which is randomly generated. Unfortunately that means we can't lock them down by a qualifier :disappointed: 

This grants access to all keys within the account.