### PR TITLE
Allow deploy user to get ApiGateway stages

### DIFF
--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -1,16 +1,16 @@
 #!/usr/bin/env node
-import * as cdk from '@aws-cdk/core';
-import * as ssm from '@aws-cdk/aws-ssm';
 import {
-     Role,
-     ServicePrincipal,
      CompositePrincipal,
-     PolicyStatement,
+     Conditions,
      Effect,
      Group,
-     User,
-     Conditions
+     PolicyStatement,
+     Role,
+     ServicePrincipal,
+     User
 } from '@aws-cdk/aws-iam';
+import * as ssm from '@aws-cdk/aws-ssm';
+import * as cdk from '@aws-cdk/core';
 import { CfnParameter } from '@aws-cdk/core';
 
 interface Policy {
@@ -608,6 +608,7 @@ export class ServiceDeployIAM extends cdk.Stack {
                          prefix: `arn:aws:apigateway:${region}::/restapis/*/stages`,
                          qualifiers: [`*`],
                          actions: [
+                              "apigateway:GET",
                               "apigateway:PATCH",
                               "apigateway:POST"
                          ]


### PR DESCRIPTION
This PR attemp to fix the `Stage already exists` issue when enabling tracing in API gateway and will potentially fix other issues related to API Gateway if it:
- hasTracingConfigured
- hasMetricsConfigured
- hasLogsConfigured
- hasTagsConfigured

For more details on how this happens, please check the attached file: 
[UB Subscription Webapp Deployment Retro.md](https://github.com/aligent/cdk-stacks/files/14676020/UB.Subscription.Webapp.Deployment.Retro.md)


