### PR TITLE
fix: add iam update policy permissions

### DIFF
--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -210,11 +210,13 @@ export class ServiceDeployIAM extends cdk.Stack {
                               "iam:PassRole",
                               "iam:GetRole",
                               "iam:DeleteRole",
+                              "iam:UpdateRole",
                               "iam:GetRolePolicy",
                               "iam:DeleteRolePolicy",
                               "iam:PutRolePolicy",
                               "iam:DetachRolePolicy",
                               "iam:AttachRolePolicy",
+                              "iam:UpdateAssumeRolePolicy",
                          ]
                     },
                     {

--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -104,9 +104,9 @@ export class ServiceDeployIAM extends cdk.Stack {
                          name: 'CLOUD_WATCH',
                          prefix: `arn:aws:logs:${region}:${accountId}:log-group:`,
                          qualifiers: [
-                              `/aws/lambda/${serviceName}*`, 
-                              `/aws/apigateway/${serviceName}*`, 
-                              `/aws/express/${serviceName}*`, 
+                              `/aws/lambda/${serviceName}*`,
+                              `/aws/apigateway/${serviceName}*`,
+                              `/aws/express/${serviceName}*`,
                               `:log-stream:*`,
                               `${serviceName}*`
                          ],
@@ -121,8 +121,18 @@ export class ServiceDeployIAM extends cdk.Stack {
                               "logs:TagResource",
                               "logs:UntagResource",
                               "logs:DescribeMetricFilters",
-                              "logs:PutMetricFilter"
+                              "logs:PutMetricFilter",
+                              "logs:ListTagsForResource",
+                              "logs:PutDataProtectionPolicy",
+                              "logs:UpdateDataProtectionPolicy",
                          ]
+                    },
+                    {
+                         name: 'CLOUD_WATCH',
+                         resources: ['*'],
+                         actions: [
+                              "logs:DeleteDataProtectionPolicy"
+                         ] 
                     },
                     {
                          name: 'CLOUD_WATCH_ALARMS',

--- a/packages/serverless-deploy-iam/test/deploy-role.test.ts
+++ b/packages/serverless-deploy-iam/test/deploy-role.test.ts
@@ -130,7 +130,10 @@ describe('Deploy user policy', () => {
                                    "logs:TagResource",
                                    "logs:UntagResource",
                                    "logs:DescribeMetricFilters",
-                                   "logs:PutMetricFilter"
+                                   "logs:PutMetricFilter",
+                                   "logs:ListTagsForResource",
+                                   "logs:PutDataProtectionPolicy",
+                                   "logs:UpdateDataProtectionPolicy",
                               ],
                               Effect: "Allow",
                               Resource: [


### PR DESCRIPTION
Adding to support CloudWatch log masking deployment through serverless: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/mask-sensitive-log-data.html