### PR TITLE
feat: add tag permissions for dynamo

### DIFF
--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -231,6 +231,9 @@ export class ServiceDeployIAM extends cdk.Stack {
             "dynamodb:CreateTable",
             "dynamodb:UpdateTable",
             "dynamodb:DeleteTable",
+            "dynamodb:ListTagsOfResource",
+            "dynamodb:TagResource",
+            "dynamodb:UntagResource",
           ],
         },
         {


### PR DESCRIPTION
Adds permission to tag DynamoDB resources. 

Serverless seems to be automatically tagging DynamoDB tables so we need this now :(