### PR TITLE
FIX: Added TagRole required by serverless

### DIFF
--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -220,6 +220,8 @@ export class ServiceDeployIAM extends cdk.Stack {
             "iam:DetachRolePolicy",
             "iam:AttachRolePolicy",
             "iam:UpdateAssumeRolePolicy",
+            "iam:TagRole",
+            "iam:UntagRole"
           ],
         },
         {

--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -221,7 +221,7 @@ export class ServiceDeployIAM extends cdk.Stack {
             "iam:AttachRolePolicy",
             "iam:UpdateAssumeRolePolicy",
             "iam:TagRole",
-            "iam:UntagRole"
+            "iam:UntagRole",
           ],
         },
         {


### PR DESCRIPTION
Serverless now requires the ability to tag roles.
This adds TagRole and UntagRole to the IAM block in app.ts