### PR TITLE
fix: add parameter hash as default value

### DIFF
--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -241,7 +241,6 @@ export class ServiceDeployIAM extends cdk.Stack {
           actions: [
             "scheduler:GetScheduleGroup",
             "scheduler:CreateScheduleGroup",
-            "scheduler:UpdateScheduleGroup",
             "scheduler:DeleteScheduleGroup",
             "scheduler:TagResource",
             "scheduler:ListTagsForResource",
@@ -541,7 +540,7 @@ export class ServiceDeployIAM extends cdk.Stack {
             new CfnParameter(this, parameterName, {
               type: "String",
               description: `Custom qualifier values provided for ${policy.name}`,
-              default: "",
+              default: PARAMETER_HASH,
             })
           );
         }


### PR DESCRIPTION
Removed invalid action.

Changed default from a blank string to the parameter hash. This was causing deployments to fail. 