### PR TITLE
add iam:CreateServiceLinkedRole to allow API GW custom domain creation

### DIFF
--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -481,17 +481,13 @@ export class ServiceDeployIAM extends cdk.Stack {
         {
           name: "IAM",
           resources: [(serviceRole.type as Role).roleArn],
-          actions: [
-            "iam:PassRole", 
-          ],
+          actions: ["iam:PassRole"],
         },
         {
           name: "IAM",
           prefix: `arn:aws:iam::${accountId}:role`,
           qualifiers: ["*"],
-          actions: [
-            "iam:CreateServiceLinkedRole"
-          ],
+          actions: ["iam:CreateServiceLinkedRole"],
         },
         {
           name: "S3",

--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -486,7 +486,9 @@ export class ServiceDeployIAM extends cdk.Stack {
         {
           name: "IAM",
           prefix: `arn:aws:iam::${accountId}:role`,
-          qualifiers: ["*"],
+          qualifiers: [
+            "aws-service-role/ops.apigateway.amazonaws.com/AWSServiceRoleForAPIGateway",
+          ],
           actions: ["iam:CreateServiceLinkedRole"],
         },
         {

--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -481,7 +481,17 @@ export class ServiceDeployIAM extends cdk.Stack {
         {
           name: "IAM",
           resources: [(serviceRole.type as Role).roleArn],
-          actions: ["iam:PassRole"],
+          actions: [
+            "iam:PassRole", 
+          ],
+        },
+        {
+          name: "IAM",
+          prefix: `arn:aws:iam::${accountId}:role`,
+          qualifiers: ["*"],
+          actions: [
+            "iam:CreateServiceLinkedRole"
+          ],
         },
         {
           name: "S3",


### PR DESCRIPTION
To address Serverless error of "Caller does not have permissions to create a Service Linked Role."