### PR TITLE
Feature/additional serverless deploy permissions

### DIFF
--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -84,7 +84,7 @@ export class ServiceDeployIAM extends cdk.Stack {
       type: new Role(this, `ServiceRole-v${version}`, {
         assumedBy: new CompositePrincipal(
           new ServicePrincipal("cloudformation.amazonaws.com"),
-          new ServicePrincipal("lambda.amazonaws.com"),
+          new ServicePrincipal("lambda.amazonaws.com")
         ),
       }),
       policies: [
@@ -534,7 +534,7 @@ export class ServiceDeployIAM extends cdk.Stack {
               type: "String",
               description: `Custom qualifier values provided for ${policy.name}`,
               default: PARAMETER_HASH,
-            }),
+            })
           );
         }
 
@@ -547,7 +547,7 @@ export class ServiceDeployIAM extends cdk.Stack {
           ServiceDeployIAM.formatResourceQualifier(
             policy.name,
             policy.prefix || "",
-            policy.qualifiers || [],
+            policy.qualifiers || []
           );
 
         store.type.addToPolicy(new PolicyStatement(policy));
@@ -604,7 +604,7 @@ export class ServiceDeployIAM extends cdk.Stack {
   static formatResourceQualifier(
     serviceName: string,
     prefix: string,
-    qualifiers: string[],
+    qualifiers: string[]
   ): string[] {
     let delimiter = "/";
     switch (serviceName) {

--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -471,7 +471,7 @@ export class ServiceDeployIAM extends cdk.Stack {
           name: "LAMBDA",
           prefix: `arn:aws:lambda:${region}:${accountId}:function:`,
           qualifiers: [`${serviceName}*`],
-          actions: ["lambda:GetFunction", "lambda:InvokeFunction"],
+          actions: ["lambda:GetFunction", "lambda:InvokeFunction", "lambda:ListTags"],
         },
         {
           name: "IAM",

--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -84,7 +84,7 @@ export class ServiceDeployIAM extends cdk.Stack {
       type: new Role(this, `ServiceRole-v${version}`, {
         assumedBy: new CompositePrincipal(
           new ServicePrincipal("cloudformation.amazonaws.com"),
-          new ServicePrincipal("lambda.amazonaws.com")
+          new ServicePrincipal("lambda.amazonaws.com"),
         ),
       }),
       policies: [
@@ -471,7 +471,11 @@ export class ServiceDeployIAM extends cdk.Stack {
           name: "LAMBDA",
           prefix: `arn:aws:lambda:${region}:${accountId}:function:`,
           qualifiers: [`${serviceName}*`],
-          actions: ["lambda:GetFunction", "lambda:InvokeFunction", "lambda:ListTags"],
+          actions: [
+            "lambda:GetFunction",
+            "lambda:InvokeFunction",
+            "lambda:ListTags",
+          ],
         },
         {
           name: "IAM",
@@ -537,7 +541,7 @@ export class ServiceDeployIAM extends cdk.Stack {
               type: "String",
               description: `Custom qualifier values provided for ${policy.name}`,
               default: "",
-            })
+            }),
           );
         }
 
@@ -550,7 +554,7 @@ export class ServiceDeployIAM extends cdk.Stack {
           ServiceDeployIAM.formatResourceQualifier(
             policy.name,
             policy.prefix || "",
-            policy.qualifiers || []
+            policy.qualifiers || [],
           );
 
         store.type.addToPolicy(new PolicyStatement(policy));
@@ -607,7 +611,7 @@ export class ServiceDeployIAM extends cdk.Stack {
   static formatResourceQualifier(
     serviceName: string,
     prefix: string,
-    qualifiers: string[]
+    qualifiers: string[],
   ): string[] {
     let delimiter = "/";
     switch (serviceName) {

--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -166,6 +166,7 @@ export class ServiceDeployIAM extends cdk.Stack {
             "iam:GetRole",
             "iam:DeleteRole",
             "iam:UpdateRole",
+            "iam:TagRole",
             "iam:GetRolePolicy",
             "iam:DeleteRolePolicy",
             "iam:PutRolePolicy",

--- a/packages/serverless-deploy-iam/test/deploy-role.test.ts
+++ b/packages/serverless-deploy-iam/test/deploy-role.test.ts
@@ -108,7 +108,11 @@ describe("Deploy user policy", () => {
         PolicyDocument: {
           Statement: arrayWith(
             objectLike({
-              Action: ["lambda:GetFunction", "lambda:InvokeFunction"],
+              Action: [
+                "lambda:GetFunction",
+                "lambda:InvokeFunction",
+                "lambda:ListTags",
+              ],
               Effect: "Allow",
               Resource: [
                 {


### PR DESCRIPTION
AWS started flagging IAM resources lacking `lambda:ListTags` permission when `lambda:GetFunction` is present. 
https://docs.aws.amazon.com/lambda/latest/dg/configuration-tags.html#fxn-tags-required-permissions