### PR TITLE
Chore/lambda event source mapping

### DIFF
--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -145,12 +145,9 @@ export class ServiceDeployIAM extends cdk.Stack {
           resources: [
             `arn:aws:lambda:${region}:${accountId}:event-source-mapping:*`,
           ],
-          actions: ["lambda:TagResource"],
-        },
-        {
-          name: "LAMBDA",
-          resources: [`*`],
           actions: [
+            "lambda:TagResource",
+            "lambda:UntagResource",
             "lambda:GetEventSourceMapping",
             "lambda:ListEventSourceMappings",
             "lambda:CreateEventSourceMapping",

--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -141,6 +141,11 @@ export class ServiceDeployIAM extends cdk.Stack {
           actions: ["lambda:*"],
         },
         {
+          name: "LAMBDA_EVENT_SOURCE_MAPPING",
+          resources: [`arn:aws:lambda:${region}:${accountId}:event-source-mapping:*`],
+          actions: ["lambda:TagResource"],
+        },
+        {
           name: "LAMBDA",
           resources: [`*`],
           actions: [
@@ -148,7 +153,6 @@ export class ServiceDeployIAM extends cdk.Stack {
             "lambda:ListEventSourceMappings",
             "lambda:CreateEventSourceMapping",
             "lambda:DeleteEventSourceMapping",
-            "lambda:TagResource",
           ],
         },
         {

--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -84,7 +84,7 @@ export class ServiceDeployIAM extends cdk.Stack {
       type: new Role(this, `ServiceRole-v${version}`, {
         assumedBy: new CompositePrincipal(
           new ServicePrincipal("cloudformation.amazonaws.com"),
-          new ServicePrincipal("lambda.amazonaws.com")
+          new ServicePrincipal("lambda.amazonaws.com"),
         ),
       }),
       policies: [
@@ -142,7 +142,9 @@ export class ServiceDeployIAM extends cdk.Stack {
         },
         {
           name: "LAMBDA_EVENT_SOURCE_MAPPING",
-          resources: [`arn:aws:lambda:${region}:${accountId}:event-source-mapping:*`],
+          resources: [
+            `arn:aws:lambda:${region}:${accountId}:event-source-mapping:*`,
+          ],
           actions: ["lambda:TagResource"],
         },
         {
@@ -539,7 +541,7 @@ export class ServiceDeployIAM extends cdk.Stack {
               type: "String",
               description: `Custom qualifier values provided for ${policy.name}`,
               default: PARAMETER_HASH,
-            })
+            }),
           );
         }
 
@@ -552,7 +554,7 @@ export class ServiceDeployIAM extends cdk.Stack {
           ServiceDeployIAM.formatResourceQualifier(
             policy.name,
             policy.prefix || "",
-            policy.qualifiers || []
+            policy.qualifiers || [],
           );
 
         store.type.addToPolicy(new PolicyStatement(policy));
@@ -609,7 +611,7 @@ export class ServiceDeployIAM extends cdk.Stack {
   static formatResourceQualifier(
     serviceName: string,
     prefix: string,
-    qualifiers: string[]
+    qualifiers: string[],
   ): string[] {
     let delimiter = "/";
     switch (serviceName) {

--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -84,7 +84,7 @@ export class ServiceDeployIAM extends cdk.Stack {
       type: new Role(this, `ServiceRole-v${version}`, {
         assumedBy: new CompositePrincipal(
           new ServicePrincipal("cloudformation.amazonaws.com"),
-          new ServicePrincipal("lambda.amazonaws.com"),
+          new ServicePrincipal("lambda.amazonaws.com")
         ),
       }),
       policies: [
@@ -541,7 +541,7 @@ export class ServiceDeployIAM extends cdk.Stack {
               type: "String",
               description: `Custom qualifier values provided for ${policy.name}`,
               default: PARAMETER_HASH,
-            }),
+            })
           );
         }
 
@@ -554,7 +554,7 @@ export class ServiceDeployIAM extends cdk.Stack {
           ServiceDeployIAM.formatResourceQualifier(
             policy.name,
             policy.prefix || "",
-            policy.qualifiers || [],
+            policy.qualifiers || []
           );
 
         store.type.addToPolicy(new PolicyStatement(policy));
@@ -611,7 +611,7 @@ export class ServiceDeployIAM extends cdk.Stack {
   static formatResourceQualifier(
     serviceName: string,
     prefix: string,
-    qualifiers: string[],
+    qualifiers: string[]
   ): string[] {
     let delimiter = "/";
     switch (serviceName) {

--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -148,6 +148,7 @@ export class ServiceDeployIAM extends cdk.Stack {
             "lambda:ListEventSourceMappings",
             "lambda:CreateEventSourceMapping",
             "lambda:DeleteEventSourceMapping",
+            "lambda:TagResource",
           ],
         },
         {


### PR DESCRIPTION
Change alternatvie to https://github.com/aligent/cdk-stacks/pull/53
This is to allow the role to tag "event-source-mapping" resources, which can't be identified by any qualifiers, e.g. 
`arn:aws:lambda:ap-southeast-2:123456789012:event-source-mapping:1bfc3b83-2c0a-49d8-b7b6-ed1dfcc099b6`

While on it, we might as well merge the ones below to this new item, as they all are about EventSourceMapping. Thoughts, @TheOrangePuff ?
```            "lambda:GetEventSourceMapping",
            "lambda:ListEventSourceMappings",
            "lambda:CreateEventSourceMapping",
            "lambda:DeleteEventSourceMapping",
```