### PR TITLE
feat: grant delete event bus

### DIFF
--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -224,6 +224,7 @@ export class ServiceDeployIAM extends cdk.Stack {
             "events:DeleteRule",
             "events:CreateEventBus",
             "events:DescribeEventBus",
+            "events:DeleteEventBus",
             "events:TagResource",
             "events:UntagResource",
           ],


### PR DESCRIPTION
Grants the deploy user permission to delete event busses (within the scope of the service name).